### PR TITLE
Pull suitable prettier and tslint settings from reaction #FF

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "nyc": "^13",
     "ts-node": "^8",
     "tslint": "^5",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3"
   },
   "engines": {
@@ -58,5 +59,11 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md"
   },
-  "types": "lib/index.d.ts"
+  "types": "lib/index.d.ts",
+  "prettier": {
+    "semi": false,
+    "singleQuote": false,
+    "trailingComma": "es5",
+    "bracketSpacing": true
+  }
 }

--- a/src/commands/hello.ts
+++ b/src/commands/hello.ts
@@ -1,7 +1,7 @@
-import {Command, flags} from '@oclif/command'
+import { Command, flags } from "@oclif/command"
 
 export default class Hello extends Command {
-  static description = 'describe the command here'
+  static description = "describe the command here"
 
   static examples = [
     `$ artsy hello
@@ -10,19 +10,19 @@ hello world from ./src/hello.ts!
   ]
 
   static flags = {
-    help: flags.help({char: 'h'}),
+    help: flags.help({ char: "h" }),
     // flag with a value (-n, --name=VALUE)
-    name: flags.string({char: 'n', description: 'name to print'}),
+    name: flags.string({ char: "n", description: "name to print" }),
     // flag with no value (-f, --force)
-    force: flags.boolean({char: 'f'}),
+    force: flags.boolean({ char: "f" }),
   }
 
-  static args = [{name: 'file'}]
+  static args = [{ name: "file" }]
 
   async run() {
-    const {args, flags} = this.parse(Hello)
+    const { args, flags } = this.parse(Hello)
 
-    const name = flags.name || 'world'
+    const name = flags.name || "world"
     this.log(`hello ${name} from ./src/commands/hello.ts`)
     if (args.file && flags.force) {
       this.log(`you input --force and --file: ${args.file}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {run} from '@oclif/command'
+export { run } from "@oclif/command"

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,21 @@
 {
-  "extends": "@oclif/tslint"
+  "extends": ["@oclif/tslint", "tslint:recommended", "tslint-config-prettier"],
+  "rules": {
+    "curly": false,
+    "interface-name": [true, "never-prefix"],
+    "max-classes-per-file": false,
+    "member-access": [false],
+    "member-ordering": false,
+    "no-console": false,
+    "no-namespace": [true, "allow-declarations"],
+    "no-shadowed-variable": false,
+    "no-unused-expression": false,
+    "no-var-requires": false,
+    "object-literal-sort-keys": false,
+    "ordered-imports": true,
+    "trailing-comma": false,
+    "variable-name": [true, "ban-keywords", "allow-leading-underscore"],
+    "jsdoc-format": false,
+    "radix": false
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,6 +2054,11 @@ tslib@^1, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
+tslint-config-prettier@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
+  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
+
 tslint-consistent-codestyle@^1.11.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.15.1.tgz#a0c5cd5a5860d40b659c490d8013c5732e02af8c"


### PR DESCRIPTION
- I removed settings that were obviously react/relay/jsx settings from reaction, as well as a custom rules directory.
- I updated the existing commands in src, based on the new settings
- I added the rule `"no-shadowed-variable": false` because shadowing seems like a thing that is pretty inherent to using oclif


My current output from type-checking: 

![image](https://user-images.githubusercontent.com/1627089/62715931-6677b200-b9cf-11e9-9198-c96388448edf.png)
