### PR TITLE
Publish for real

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/artsy-cli/.npmrc
       - run:
           name: Publish package
-          command: npm publish --dry-run
+          command: npm publish
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR removes the dry-run flag so that the release branch will really deploy to npm.