### PR TITLE
Add a Gravity fetching client

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
+    "@types/node-fetch": "^2.5.0",
+    "node-fetch": "^2.6.0",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/src/lib/gravity/index.ts
+++ b/src/lib/gravity/index.ts
@@ -1,0 +1,25 @@
+import fetch from "node-fetch"
+
+class Gravity {
+  static HOSTS = {
+    staging: "stagingapi.artsy.net",
+    production: "api.artsy.net",
+  }
+
+  async get(endpoint: string) {
+    const token: string = process.env.TOKEN! // temp until our auth/token plumbing is hooked up
+
+    const gravityUrl: string = this.url(endpoint)
+    const headers = { "X-Access-Token": token }
+    const response = await fetch(gravityUrl, { headers })
+
+    return response
+  }
+
+  url(endpoint: string): string {
+    const host = Gravity.HOSTS.staging
+    return `https://${host}/api/v1/${endpoint}`
+  }
+}
+
+export default Gravity

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,6 +269,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.0.tgz#1c55616a4591bdd15a389fbd0da4a55b9502add5"
+  integrity sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "12.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
@@ -1401,6 +1408,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
Adds a `Gravity` class that can be instantiated and supplied to any command. 

This class will know about token stuff and about details of how to construct an url, given a resource. I.e. turn `artwork/123abc` into `https://api.artsy.net/api/v1/artwork/123abc` and fetch it.

I made it stateful, thinking ahead to tokens, but maybe it doesn't need to be 🤷‍♂ 

In my WIP branch this gets used in a Command's `run` function as follows:

```js
  async run() {
    const gravity = new Gravity()
    const response = await gravity.get(`something/123`)
    if (response.status === 200) {
      // do something with response.json()
    } else {
      // cry
    }
  }
```
