### PR TITLE
Add an `identify` command #FF

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "cli-ux": "^5.3.1",
     "dotenv": "^8.0.0",
     "node-fetch": "^2.6.0",
-    "nock": "^10.0.6",
     "tslib": "^1"
   },
   "devDependencies": {
@@ -26,9 +25,11 @@
     "@types/chai": "^4",
     "@types/mocha": "^5",
     "@types/node": "^10",
+    "@types/node-fetch": "^2.5.0",
     "chai": "^4",
     "globby": "^10",
     "mocha": "^5",
+    "nock": "^10.0.6",
     "nyc": "^13",
     "ts-node": "^8",
     "tslint": "^5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cli-ux": "^5.3.1",
     "dotenv": "^8.0.0",
     "node-fetch": "^2.6.0",
+    "nock": "^10.0.6",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/src/commands/identify.ts
+++ b/src/commands/identify.ts
@@ -1,0 +1,41 @@
+import { Command, flags } from "@oclif/command"
+import Gravity from "../lib/gravity"
+
+export default class Identify extends Command {
+  static description = "Identify a Gravity resource by its BSON ID"
+
+  static flags = {
+    help: flags.help({ char: "h" }),
+  }
+
+  static args = [{ name: "id" }]
+
+  static collectionsToCheck = [
+    { name: "Artist", endpoint: "artist" },
+    { name: "Artwork", endpoint: "artwork" },
+    { name: "Partner", endpoint: "partner" },
+  ]
+
+  async run() {
+    const gravity = new Gravity()
+    const { args } = this.parse(Identify)
+    const { id } = args
+
+    const gravityPromises = Identify.collectionsToCheck.map(collection => {
+      const resource = `${collection.endpoint}/${id}`
+      return gravity.get(resource)
+    })
+
+    const gravityResponses = await Promise.all(gravityPromises)
+    const foundIndex = gravityResponses.findIndex(r => r.status === 200)
+
+    if (foundIndex >= 0) {
+      const foundCollection = Identify.collectionsToCheck[foundIndex]
+      const foundResource = `${foundCollection.endpoint}/${id}`
+      this.log(`${foundCollection.name} ${gravity.url(foundResource)}`)
+    } else {
+      const collections = Identify.collectionsToCheck.map(c => c.name)
+      this.log(`Nothing found in: ${collections.join(", ")}`)
+    }
+  }
+}

--- a/src/commands/identify.ts
+++ b/src/commands/identify.ts
@@ -10,7 +10,7 @@ export default class Identify extends Command {
 
   static args = [{ name: "id" }]
 
-  static collectionsToCheck = [
+  static collectionsToCheck: CollectionMapping[] = [
     { name: "Artist", endpoint: "artist" },
     { name: "Artwork", endpoint: "artwork" },
     { name: "Partner", endpoint: "partner" },
@@ -38,4 +38,12 @@ export default class Identify extends Command {
       this.log(`Nothing found in: ${collections.join(", ")}`)
     }
   }
+}
+
+interface CollectionMapping {
+  /** Name of the Gravity resource */
+  name: string
+
+  /** The name of the collection as it appears in the GET endpoint for the resource, i.e. /api/v1/<endpoint>/:id */
+  endpoint: string
 }

--- a/src/commands/identify.ts
+++ b/src/commands/identify.ts
@@ -32,7 +32,7 @@ export default class Identify extends Command {
     if (foundIndex >= 0) {
       const foundCollection = Identify.collectionsToCheck[foundIndex]
       const foundResource = `${foundCollection.endpoint}/${id}`
-      this.log(`${foundCollection.name} ${gravity.url(foundResource)}`)
+      this.log(`${foundCollection.name} ${gravity.url(`api/v1/${foundResource}`)}`)
     } else {
       const collections = Identify.collectionsToCheck.map(c => c.name)
       this.log(`Nothing found in: ${collections.join(", ")}`)

--- a/test/commands/identify.test.ts
+++ b/test/commands/identify.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@oclif/test"
+
+describe("identify", () => {
+  describe("when the artwork exists", () => {
+    test
+      .nock("https://stagingapi.artsy.net", api =>
+        api
+          .get("/api/v1/artist/abc123")
+          .reply(404)
+          .get("/api/v1/artwork/abc123")
+          .reply(200)
+          .get("/api/v1/partner/abc123")
+          .reply(404)
+      )
+      .stdout()
+      .command(["identify", "abc123"])
+      .it("displays a found artwork message", ctx => {
+        expect(ctx.stdout).to.equal(
+          "Artwork https://stagingapi.artsy.net/api/v1/artwork/abc123\n"
+        )
+      })
+  })
+
+  describe("when the artist exists", () => {
+    test
+      .nock("https://stagingapi.artsy.net", api =>
+        api
+          .get("/api/v1/artist/abc123")
+          .reply(200)
+          .get("/api/v1/artwork/abc123")
+          .reply(404)
+          .get("/api/v1/partner/abc123")
+          .reply(404)
+      )
+      .stdout()
+      .command(["identify", "abc123"])
+      .it("displays a found artist message", ctx => {
+        expect(ctx.stdout).to.equal(
+          "Artist https://stagingapi.artsy.net/api/v1/artist/abc123\n"
+        )
+      })
+  })
+
+  describe("when the partner exists", () => {
+    test
+      .nock("https://stagingapi.artsy.net", api =>
+        api
+          .get("/api/v1/artist/abc123")
+          .reply(404)
+          .get("/api/v1/artwork/abc123")
+          .reply(404)
+          .get("/api/v1/partner/abc123")
+          .reply(200)
+      )
+      .stdout()
+      .command(["identify", "abc123"])
+      .it("displays a found partner message", ctx => {
+        expect(ctx.stdout).to.equal(
+          "Partner https://stagingapi.artsy.net/api/v1/partner/abc123\n"
+        )
+      })
+  })
+
+  describe("when nothing is found", () => {
+    test
+      .nock("https://stagingapi.artsy.net", api =>
+        api
+          .get("/api/v1/artwork/abc123")
+          .reply(404)
+          .get("/api/v1/artist/abc123")
+          .reply(404)
+          .get("/api/v1/partner/abc123")
+          .reply(404)
+      )
+      .stdout()
+      .command(["identify", "abc123"])
+      .it("displays a not-found message", ctx => {
+        expect(ctx.stdout).to.equal(
+          "Nothing found in: Artist, Artwork, Partner\n"
+        )
+      })
+  })
+})

--- a/tslint.json
+++ b/tslint.json
@@ -16,6 +16,7 @@
     "trailing-comma": false,
     "variable-name": [true, "ban-keywords", "allow-leading-underscore"],
     "jsdoc-format": false,
-    "radix": false
+    "radix": false,
+    "no-single-line-block-comment": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,7 +432,7 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
-chai@^4:
+chai@^4, chai@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -612,6 +612,11 @@ deep-eql@^3.0.1:
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
   dependencies:
     type-detect "^4.0.0"
+
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -1181,6 +1186,11 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -1260,7 +1270,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.11, lodash@^4.17.13:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -1418,6 +1428,21 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nock@^10.0.6:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
+  integrity sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==
+  dependencies:
+    chai "^4.1.2"
+    debug "^4.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
 
 node-fetch@^2.6.0:
   version "2.6.0"
@@ -1653,6 +1678,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
+  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -1684,6 +1714,11 @@ qqjs@^0.3.10:
     tar-fs "^2.0.0"
     tmp "^0.1.0"
     write-json-file "^4.1.1"
+
+qs@^6.5.1:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 read-pkg-up@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Adds an `identify` command to identify an Artist, Artwork or Partner based on its BSON id. This also demonstrates the oclif way of mocking network requests in the accompanying test.

![Screen Shot 2019-09-01 at 5 40 30 PM](https://user-images.githubusercontent.com/140521/64082613-a89ac780-ccdf-11e9-9bb3-7bf91c963986.png)
 
Still supplying the token as an env var, till we get logins wired up.