### PR TITLE
Add circleci context for publishing permissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - yarn/update-cache
       - yarn/test
       - yarn/auto-release:
+          context: npm-deploy
           filters:
             branches:
               only: master


### PR DESCRIPTION
Third time is the charm?

This adds a missing [context](https://circleci.com/docs/2.0/contexts/) which contains the environment variables needed for publishing. 