### PR TITLE
[WIP] Add error handling to login command

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -24,7 +24,15 @@ export default class Login extends Command {
       password,
     })
 
-    Config.writeToken(result.access_token)
-    this.log(result.access_token)
+    const errorDescription = (result as GravityErrorResponse).error_description
+
+    if (errorDescription) {
+      this.error(errorDescription)
+    }
+
+    const accessToken = (result as GravityAccessTokenResponse).access_token
+
+    Config.writeToken(accessToken)
+    this.log(accessToken)
   }
 }

--- a/src/lib/gravity/index.ts
+++ b/src/lib/gravity/index.ts
@@ -7,9 +7,11 @@ class Gravity {
     production: "api.artsy.net",
   }
 
-  async getAccessToken(credentials: Credentials) {
+  async getAccessToken(
+    credentials: GravityCredentials
+  ): Promise<GravityAccessTokenResponse | GravityErrorResponse> {
     const gravityUrl = this.url("oauth2/access_token")
-    const body: AccessTokenRequest = {
+    const body: GravityAccessTokenRequest = {
       client_id: process.env.CLIENT_ID!,
       client_secret: process.env.CLIENT_SECRET!,
       grant_type: "credentials",
@@ -24,7 +26,7 @@ class Gravity {
 
     const json = await response.json()
 
-    return json as AccessTokenResponse
+    return json
   }
 
   async get(endpoint: string) {
@@ -44,19 +46,3 @@ class Gravity {
 }
 
 export default Gravity
-
-export interface Credentials {
-  email: string
-  password: string
-}
-
-interface AccessTokenRequest extends Credentials {
-  grant_type: string
-  client_id: string
-  client_secret: string
-}
-
-interface AccessTokenResponse {
-  access_token: string
-  expires_in: string
-}

--- a/src/types/gravity.d.ts
+++ b/src/types/gravity.d.ts
@@ -1,0 +1,20 @@
+interface GravityCredentials {
+  email: string
+  password: string
+}
+
+interface GravityAccessTokenRequest extends GravityCredentials {
+  grant_type: string
+  client_id: string
+  client_secret: string
+}
+
+interface GravityAccessTokenResponse {
+  access_token: string
+  expires_in: string
+}
+
+interface GravityErrorResponse {
+  error: string
+  error_description: string
+}


### PR DESCRIPTION
Error the login CLI command if Gravity returns an error response.

```
$ artsy login
Email: user@example.com
Password: **************
Authenticating against stagingapi.artsy.net for user@example.com...
 ›   Error: invalid client_id: shhh
```

```
$ artsy login
Email: user@example.com
Password: **************
Authenticating against stagingapi.artsy.net for user@example.com...
 ›   Error: invalid email or password
```