### PR TITLE
fix: port opsgenie nextOnCall fix to standup-reminder

### DIFF
--- a/src/commands/scheduled/standup-reminder.ts
+++ b/src/commands/scheduled/standup-reminder.ts
@@ -51,7 +51,7 @@ export default class StandupReminder extends Command {
     const opsgenie = new Opsgenie()
     const onCalls = await opsgenie.scheduleNextOnCalls("Engineering On Call")
 
-    return onCalls.data.nextOnCallRecipients.map((participant: any) => {
+    return onCalls.data.exactNextOnCallRecipients.map((participant: any) => {
       return participant.name
     })
   }

--- a/test/commands/scheduled/standup-reminder.test.ts
+++ b/test/commands/scheduled/standup-reminder.test.ts
@@ -22,7 +22,7 @@ describe("scheduled:standup-reminder", () => {
         .get(/\/v2\/schedules\/.*\/next-on-calls.*/)
         .reply(200, {
           data: {
-            nextOnCallRecipients: [
+            exactNextOnCallRecipients: [
               { name: "justin@example.com" },
               { name: "steve@example.com" },
             ],


### PR DESCRIPTION
This fix was applied to the `on-call:next` command but needs to be ported here as well.