### PR TITLE
feat: update login to use OAuth flow

### DIFF
--- a/src/commands/identify.ts
+++ b/src/commands/identify.ts
@@ -1,4 +1,5 @@
 import Command from "../base"
+import { Config } from "../config"
 
 import Gravity from "../utils/gravity"
 
@@ -22,6 +23,9 @@ export default class Identify extends Command {
     const { args } = this.parse(Identify)
     const { id } = args
 
+    if (!Config.readToken())
+      this.error("You are not logged in. Run `artsy login`.")
+
     const gravityPromises = Identify.collectionsToCheck.map(collection => {
       const resource = `${collection.endpoint}/${id}`
       return gravity.get(resource)
@@ -34,7 +38,7 @@ export default class Identify extends Command {
       const foundCollection = Identify.collectionsToCheck[foundIndex]
       const foundResource = `${foundCollection.endpoint}/${id}`
       this.log(
-        `${foundCollection.name} ${gravity.url(`api/v1/${foundResource}`)}`
+        `${foundCollection.name} ${Gravity.url(`api/v1/${foundResource}`)}`
       )
     } else {
       const collections = Identify.collectionsToCheck.map(c => c.name)

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,4 +1,6 @@
 import cli from "cli-ux"
+import fetch from "node-fetch"
+import { parse } from "querystring"
 import Command from "../base"
 import { Config } from "../config"
 import Gravity from "../utils/gravity"
@@ -12,17 +14,47 @@ export default class Login extends Command {
   }
 
   async run() {
-    const email = await cli.prompt("Email", { type: "normal" })
-    const password = await cli.prompt("Password", { type: "hide" })
+    await cli.anykey("Ready! Press any key to initiate authorization flow")
 
-    this.log(`Authenticating against stagingapi.artsy.net for ${email}...`)
+    cli.action.start("Waiting for response")
 
-    const result = await new Gravity().getAccessToken({
-      email,
-      password,
-    })
+    const server = require("http")
+      .createServer(async (req: any, res: any) => {
+        const url = new URL(req.url, Gravity.urls.callback)
+        const query = parse(url.search.substr(1))
 
-    Config.writeToken(result.access_token)
-    this.log(result.access_token)
+        res.writeHead(200, { "Content-Type": "text/plain" })
+        res.end("Thank you. You may return to the Artsy CLI now.")
+
+        req.connection.end()
+        req.connection.destroy()
+        server.close()
+
+        if (query.code) {
+          const params = new URLSearchParams()
+          params.append("code", query.code.toString())
+          params.append("client_id", process.env.CLIENT_ID as string)
+          params.append("client_secret", process.env.CLIENT_SECRET as string)
+          params.append("grant_type", "authorization_code")
+          params.append("scope", "offline_access")
+
+          const response = await fetch(Gravity.urls.access_token, {
+            method: "POST",
+            body: params,
+          })
+
+          if (!response.ok)
+            this.error(`${response.status} ${response.statusText}`)
+
+          const data = await response.json()
+          Config.writeToken(data.access_token)
+
+          cli.action.stop("logged in!")
+        }
+      })
+      .listen(Gravity.REDIRECT_PORT)
+    await cli.open(
+      `${Gravity.urls.auth}?client_id=${process.env.CLIENT_ID}&redirect_uri=http://127.0.0.1:${Gravity.REDIRECT_PORT}&response_type=code`
+    )
   }
 }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,33 @@
+import { Command } from "@oclif/command"
+import fetch from "node-fetch"
+import { Config } from "../config"
+import Gravity from "../utils/gravity"
+
+export default class Logout extends Command {
+  static description = "Expire your local auth token."
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  async run() {
+    const token = Config.readToken()
+
+    if (!token) {
+      this.log("Already logged out!")
+      this.exit()
+    }
+
+    const params = new URLSearchParams()
+    params.append("access_token", token)
+    const response = await fetch(Gravity.urls.access_tokens, {
+      method: "DELETE",
+      body: params,
+    })
+
+    if (!response.ok) this.error(`${response.status} ${response.statusText}`)
+
+    Config.writeToken("")
+    this.log("Logged out!")
+  }
+}

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,48 @@
+import { Command } from "@oclif/command"
+import cli from "cli-ux"
+import fetch from "node-fetch"
+import { Config } from "../config"
+import Gravity from "../utils/gravity"
+
+export default class WhoAmI extends Command {
+  static description = "Who are you?"
+
+  static flags = {
+    ...Command.flags,
+    ...cli.table.flags(),
+  }
+
+  async run() {
+    const { flags } = this.parse(WhoAmI)
+
+    const token = Config.readToken()
+    if (!token) this.error("You are not logged in. Run `artsy login`.")
+
+    const userResponse = await fetch(Gravity.urls.current_user, {
+      headers: { "X-Access-Token": Config.readToken() },
+    })
+
+    const json = await userResponse.json()
+
+    const detailsResponse = await fetch(json._links.user_detail.href, {
+      headers: { "X-Access-Token": token },
+    })
+
+    const detailsJson = await detailsResponse.json()
+    cli.table(
+      [detailsJson],
+      {
+        name: {},
+        email: {},
+        phone: {},
+        type: {},
+        timezone: {},
+        timezone_code: {},
+      },
+      {
+        printLine: this.log,
+        ...flags,
+      }
+    )
+  }
+}

--- a/src/utils/gravity.ts
+++ b/src/utils/gravity.ts
@@ -2,13 +2,25 @@ import fetch from "node-fetch"
 import { Config } from "../config"
 
 class Gravity {
-  static HOSTS = {
-    staging: "stagingapi.artsy.net",
-    production: "api.artsy.net",
+  static BASE_URL = `https://api.artsy.net/`
+  static REDIRECT_PORT = 27879
+
+  static url(endpoint: string) {
+    return `${Gravity.BASE_URL}${endpoint}`
+  }
+
+  static urls = {
+    current_user: Gravity.url("api/current_user"),
+    auth: Gravity.url("oauth2/authorize"),
+    access_token: Gravity.url("oauth2/access_token"),
+    access_tokens: Gravity.url("api/tokens/access_token"),
+    user_details: Gravity.url("api/current_user"),
+    // tslint:disable-next-line:no-http-string
+    callback: `http://127.0.0.1:${Gravity.REDIRECT_PORT}`,
   }
 
   async getAccessToken(credentials: Credentials) {
-    const gravityUrl = this.url("oauth2/access_token")
+    const gravityUrl = Gravity.urls.access_token
     const body: AccessTokenRequest = {
       client_id: process.env.CLIENT_ID!,
       client_secret: process.env.CLIENT_SECRET!,
@@ -30,16 +42,11 @@ class Gravity {
   async get(endpoint: string) {
     const token: string = Config.readToken()
 
-    const gravityUrl: string = this.url(`api/v1/${endpoint}`)
+    const gravityUrl: string = Gravity.url(`api/v1/${endpoint}`)
     const headers = { "X-Access-Token": token }
     const response = await fetch(gravityUrl, { headers })
 
     return response
-  }
-
-  url(endpoint: string): string {
-    const host = Gravity.HOSTS.staging
-    return `https://${host}/${endpoint}`
   }
 }
 

--- a/test/commands/identify.test.ts
+++ b/test/commands/identify.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@oclif/test"
 describe("identify", () => {
   describe("when the artwork exists", () => {
     test
-      .nock("https://stagingapi.artsy.net", api =>
+      .nock("https://api.artsy.net", api =>
         api
           .get("/api/v1/artist/abc123")
           .reply(404)
@@ -16,14 +16,14 @@ describe("identify", () => {
       .command(["identify", "abc123"])
       .it("displays a found artwork message", ctx => {
         expect(ctx.stdout).to.equal(
-          "Artwork https://stagingapi.artsy.net/api/v1/artwork/abc123\n"
+          "Artwork https://api.artsy.net/api/v1/artwork/abc123\n"
         )
       })
   })
 
   describe("when the artist exists", () => {
     test
-      .nock("https://stagingapi.artsy.net", api =>
+      .nock("https://api.artsy.net", api =>
         api
           .get("/api/v1/artist/abc123")
           .reply(200)
@@ -36,14 +36,14 @@ describe("identify", () => {
       .command(["identify", "abc123"])
       .it("displays a found artist message", ctx => {
         expect(ctx.stdout).to.equal(
-          "Artist https://stagingapi.artsy.net/api/v1/artist/abc123\n"
+          "Artist https://api.artsy.net/api/v1/artist/abc123\n"
         )
       })
   })
 
   describe("when the partner exists", () => {
     test
-      .nock("https://stagingapi.artsy.net", api =>
+      .nock("https://api.artsy.net", api =>
         api
           .get("/api/v1/artist/abc123")
           .reply(404)
@@ -56,14 +56,14 @@ describe("identify", () => {
       .command(["identify", "abc123"])
       .it("displays a found partner message", ctx => {
         expect(ctx.stdout).to.equal(
-          "Partner https://stagingapi.artsy.net/api/v1/partner/abc123\n"
+          "Partner https://api.artsy.net/api/v1/partner/abc123\n"
         )
       })
   })
 
   describe("when nothing is found", () => {
     test
-      .nock("https://stagingapi.artsy.net", api =>
+      .nock("https://api.artsy.net", api =>
         api
           .get("/api/v1/artwork/abc123")
           .reply(404)


### PR DESCRIPTION
- [x] Initiate Oauth handshake
- [x] Receive OAuth authorization code
- [x] Exchange OAuth authorization code for access token
- [x] Store access token into config
- [x] Support logout with access explicit access token expiration

This also adds an `artsy whoami` command to verify logged in state.

Experimented with some oauth flows here and in https://github.com/artsy/eigen/pull/4467 during Future Friday last week.

#FutureFriday #FF

### Screen Recording

https://user-images.githubusercontent.com/123595/108740230-73052200-7503-11eb-981c-2b00bb69ce55.mov
