### PR TITLE
chore: split standup reminder from upcoming on-call shift reminder

### DIFF
--- a/src/commands/scheduled/next-on-call.ts
+++ b/src/commands/scheduled/next-on-call.ts
@@ -1,0 +1,49 @@
+import Command from "../../base"
+
+import { Opsgenie } from "../../utils/opsgenie"
+import { convertEmailsToSlackMentions } from "../../utils/slack"
+
+export default class NextOnCall extends Command {
+  static urls: { [key: string]: string } = {
+    engineeringSupport:
+      "https://github.com/artsy/README/tree/master/playbooks/support#preparing-for-your-on-call-shift",
+  }
+
+  static description = "Remind members with upcoming on-call shifts."
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  async run() {
+    const emails = await this.nextOnCallEmailsFromOpsGenie()
+    const mentions = await convertEmailsToSlackMentions(emails)
+
+    const payload = JSON.stringify({
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `${mentions.join(
+              ", "
+            )} looks like you have on-call shifts coming up! Check out the <${
+              NextOnCall.urls.engineeringSupport
+            }|Engineering Support doc> to prep. You've got this! :+1:`,
+          },
+        },
+      ],
+    })
+
+    this.log(payload)
+  }
+
+  async nextOnCallEmailsFromOpsGenie() {
+    const opsgenie = new Opsgenie()
+    const onCalls = await opsgenie.scheduleNextOnCalls("Engineering On Call")
+
+    return onCalls.data.exactNextOnCallRecipients.map((participant: any) => {
+      return participant.name
+    })
+  }
+}

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,0 +1,16 @@
+import { WebClient } from "@slack/client"
+
+const convertEmailsToSlackMentions = async (emails: string[]) => {
+  const slackToken = process.env.SLACK_WEB_API_TOKEN
+  const web = new WebClient(slackToken)
+  const users = await Promise.all(
+    emails.map(email => web.users.lookupByEmail({ email }))
+  )
+
+  return users
+    .filter(r => r.ok) // Filter out any failed lookups.
+    .map((response: any) => response.user.id as string)
+    .map(id => `<@${id}>`) // See: https://api.slack.com/docs/message-formatting#linking_to_channels_and_users
+}
+
+export { convertEmailsToSlackMentions }

--- a/test/commands/scheduled/next-on-call.test.ts
+++ b/test/commands/scheduled/next-on-call.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@oclif/test"
+
+describe("scheduled:next-on-call", () => {
+  beforeEach(() => {
+    process.env.OPSGENIE_API_KEY = "test"
+  })
+  afterEach(() => {
+    delete process.env.OPSGENIE_API_KEY
+  })
+  test
+    .nock("https://api.opsgenie.com", api =>
+      api.get(/\/v2\/schedules\/.*\/next-on-calls.*/).reply(200, {
+        data: {
+          exactNextOnCallRecipients: [
+            { name: "justin@example.com" },
+            { name: "steve@example.com" },
+          ],
+        },
+      })
+    )
+    .nock("https://slack.com/api", api =>
+      api
+        .post("/users.lookupByEmail", /email=justin%40example.com/)
+        .reply(200, {
+          ok: true,
+          user: {
+            id: "justin",
+          },
+        })
+        .post("/users.lookupByEmail", /email=steve%40example.com/)
+        .reply(200, {
+          ok: true,
+          user: {
+            id: "steve",
+          },
+        })
+    )
+    .stdout()
+    .command(["scheduled:next-on-call"])
+    .it(
+      "returns Slack-formatted upcoming on-call shift reminder message",
+      ctx => {
+        expect(ctx.stdout.trim()).to.eq(
+          JSON.stringify({
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text:
+                    "<@justin>, <@steve> looks like you have on-call shifts coming up! Check out the <https://github.com/artsy/README/tree/master/playbooks/support#preparing-for-your-on-call-shift|Engineering Support doc> to prep. You've got this! :+1:",
+                },
+              },
+            ],
+          })
+        )
+      }
+    )
+})


### PR DESCRIPTION
Split these messages so we can send them on different schedules.